### PR TITLE
保存済みの名称一覧を取得できるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ const { JSONDriver } = require('clay-driver-memory')
 API
 ---------
 
-# clay-driver-json@2.1.1
+# clay-driver-json@2.1.2
 
 Clay driver to save data into JSON files
 

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-driver-json@2.1.1
+# clay-driver-json@2.1.2
 
 Clay driver to save data into JSON files
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * Clay driver to save data into JSON files
  * @module clay-driver-json
- * @version 2.1.1
+ * @version 2.1.2
  */
 
 'use strict'

--- a/lib/json_driver.js
+++ b/lib/json_driver.js
@@ -9,11 +9,11 @@
 
 const co = require('co')
 const path = require('path')
+const aglob = require('aglob')
 const asleep = require('asleep')
 const { readFileAsync } = require('asfs')
 const { LogPrefixes } = require('clay-constants')
 const { MemoryDriver } = require('clay-driver-memory')
-const { spinalcase } = require('stringcase')
 const { serialize, deserialize } = require('clay-serial')
 const writeout = require('writeout')
 
@@ -57,6 +57,22 @@ class JSONDriver extends MemoryDriver {
       } else {
         return false
       }
+    })
+  }
+
+  /** @inheritdoc */
+  storageKeys () {
+    const s = this
+    return co(function * () {
+      let storageKeys = Object.keys(s._storages || {})
+      let filenames = yield aglob(s.getFilename('*'))
+      for (let filename of filenames) {
+        let storageKey = path.basename(filename, '.json')
+        if (!~storageKeys.indexOf(storageKey)) {
+          storageKeys.push(storageKey)
+        }
+      }
+      return storageKeys
     })
   }
 
@@ -131,7 +147,7 @@ class JSONDriver extends MemoryDriver {
 
   getFilename (resourceName) {
     const s = this
-    return path.join(s._dirname, `${spinalcase(resourceName)}.json`)
+    return path.join(s._dirname, `${resourceName}.json`)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/realglobe-Inc/clay-driver-json#readme",
   "dependencies": {
+    "aglob": "^2.0.1",
     "asfs": "^1.2.2",
     "asleep": "^1.0.3",
     "clay-driver-memory": "^2.1.3",
@@ -39,7 +40,7 @@
     "ape-tasking": "^4.0.9",
     "ape-tmpl": "^5.0.20",
     "ape-updating": "^4.1.0",
-    "clay-driver-tests": "^1.1.1",
+    "clay-driver-tests": "^1.1.2",
     "coz": "^6.0.20",
     "injectmock": "^2.0.0",
     "request": "^2.79.0",

--- a/test/json_driver_test.js
+++ b/test/json_driver_test.js
@@ -60,6 +60,9 @@ describe('json-driver', function () {
     let destroyed2 = yield driver.destroy('users', one.id)
     equal(destroyed2, 0)
 
+    let resources = yield driver.resources()
+    deepEqual(resources, [ { name: 'users', version: 'latest' } ])
+
     equal((yield driver.list('users')).meta.total, 1)
     yield driver.flush()
     equal((yield driver.list('users')).meta.total, 1)


### PR DESCRIPTION
`.resources()`メソッドのために、保存済みのJSONファイル名をiterateするようにした。

JSONDriverではメモリ上の辞書と、JSONファイルに反映済みの辞書が混在しているので、両方から探すようにしてある